### PR TITLE
auth: key is truncated too early

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -108,7 +108,7 @@ func (a Authenticator) GetCode(c int, now int64) (int, int64, error) {
 	t_chunk := (now / int64(a.Interval)) + int64(c)
 
 	buf_in := bytes.Buffer{}
-	err := binary.Write(&buf_in, binary.BigEndian, int32(t_chunk))
+	err := binary.Write(&buf_in, binary.BigEndian, int64(t_chunk))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func TestGen(t *testing.T) {
-	s := GenSecretKey()
+	s, err := GenSecretKey("sha1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(s) < 40 {
 		t.Errorf("the key must be 40 characters or more. not %d", len(s))
 	}


### PR DESCRIPTION
Closes #2

Reported-by: Clinton Begin
Signed-off-by: Vincent Batts vbatts@hashbangbash.com
